### PR TITLE
Add fastclick library and fix the 300ms delay on ios

### DIFF
--- a/HLRproject/package.json
+++ b/HLRproject/package.json
@@ -23,7 +23,8 @@
     "core-js": "^2.4.1",
     "ng2-bootstrap": "^1.6.1",
     "rxjs": "^5.1.0",
-    "zone.js": "^0.7.6"
+    "zone.js": "^0.7.6",
+    "fastclick": "^1.0.6"
   },
   "devDependencies": {
     "@angular/cli": "1.0.0-rc.0",

--- a/HLRproject/src/index.html
+++ b/HLRproject/src/index.html
@@ -12,10 +12,21 @@
   <!-- Make it possible to run ass web app on iOS -->
   <meta name="apple-mobile-web-app-capable" content="yes" />
 
+  <!-- Import library fast click to remove 300ms delay -->
+  <script type='application/javascript' src='../node_modules/fastclick/lib/fastclick.js'></script>
+
 
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
+
+  <!-- JavaScript to activate fastclick -->
+  <script>if ('addEventListener' in document) {
+    document.addEventListener('DOMContentLoaded', function() {
+      FastClick.attach(document.body);
+    }, false);
+  }</script>
+
 <div class="screen">
     <app-root>Loading...</app-root>
 </div>


### PR DESCRIPTION
Added the fastclick library, npm update needed.
Implemented the usage as an basic javascript, will remove the 300ms on iOS webapp fullscreen. 