### PR TITLE
Make inactive HLR-steps unclickable and faded out.

### DIFF
--- a/HLRproject/src/components/hlr/hlrflow/hlrstep/hlrstep.component.css
+++ b/HLRproject/src/components/hlr/hlrflow/hlrstep/hlrstep.component.css
@@ -41,9 +41,6 @@
   visibility: hidden;
 }
 
-
-
-
 .checkb {
   background-color: white;
   border-radius: 8px;
@@ -53,9 +50,18 @@
   padding: 8px 30px;
   width: 100%;
 }
+
 .checkb:active {
   background-color: darkgreen;
 }
+
 .green-box {
   background-color: green;
 }
+
+.disabled-step{
+  pointer-events: none;
+  background-color: rgba(191,191,191,0.4);
+  opacity: 0.7;
+}
+

--- a/HLRproject/src/components/hlr/hlrflow/hlrstep/hlrstep.component.html
+++ b/HLRproject/src/components/hlr/hlrflow/hlrstep/hlrstep.component.html
@@ -1,4 +1,4 @@
-<div class="panel panel-default text-center step" [ngClass]="(step.index == step.currentStepIndex) ? 'hlr-border' : ''">
+<div class="panel panel-default text-center step" [ngClass]="(step.index == step.currentStepIndex) ? 'hlr-border' : 'disabled-step'">
 
    <!-- START OF BOLT BUTTON -->
 


### PR DESCRIPTION
This merge will resolve issue #44 by making previous and future hlr-steps unclickable while not currently active. A gray mask is also applied to these to show that they are unclickable and inactive.